### PR TITLE
test: add unit and integration test coverage

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@1.x
     with:
-      enable_backend_testing: false
+      enable_backend_testing: true
       enable_phpstan: true
       php_versions: '["8.2", "8.3", "8.4", "8.5"]'
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "flarum/core": "^1.8.0",
+        "flarum/core": "^1.8.13",
         "fof/forum-widgets-core": "^1.0.0"
     },
     "support": {

--- a/src/GuestUserCount.php
+++ b/src/GuestUserCount.php
@@ -98,7 +98,13 @@ class GuestUserCount
 
         $guestCount = 0;
         foreach ($recentlyActiveSessionFiles as $file) {
-            $session = unserialize(file_get_contents($file->getRealPath()));
+            $contents = @file_get_contents($file->getRealPath());
+
+            if ($contents === false) {
+                continue;
+            }
+
+            $session = @unserialize($contents, ['allowed_classes' => false]);
             if (is_array($session) && ! isset($session['access_token'])) {
                 $guestCount++;
             }

--- a/tests/integration/ForumAttributeTest.php
+++ b/tests/integration/ForumAttributeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of ianm/online-guests.
+ *
+ * Copyright (c) IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\OnlineGuests\Tests\integration;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ForumAttributeTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-forum-widgets-core', 'ianm-online-guests');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    private function grantPermissionTo(int $groupId): void
+    {
+        $this->prepareDatabase([
+            'group_permission' => [
+                ['group_id' => $groupId, 'permission' => 'viewOnlineGuests'],
+            ],
+        ]);
+    }
+
+    private function forumAttributes(?int $authenticatedAs = null): array
+    {
+        $options = [];
+
+        if ($authenticatedAs !== null) {
+            $options['authenticatedAs'] = $authenticatedAs;
+        }
+
+        $response = $this->send(
+            $this->request('GET', '/api', $options)
+        );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['data']['attributes'] ?? [];
+    }
+
+    /**
+     * @test
+     */
+    public function guest_without_permission_does_not_receive_the_attribute(): void
+    {
+        $attributes = $this->forumAttributes();
+
+        $this->assertArrayNotHasKey('onlineGuests', $attributes);
+    }
+
+    /**
+     * @test
+     */
+    public function member_without_permission_does_not_receive_the_attribute(): void
+    {
+        $attributes = $this->forumAttributes(2);
+
+        $this->assertArrayNotHasKey('onlineGuests', $attributes);
+    }
+
+    /**
+     * @test
+     */
+    public function member_with_permission_receives_an_integer_count(): void
+    {
+        $this->grantPermissionTo(Group::MEMBER_ID);
+
+        $attributes = $this->forumAttributes(2);
+
+        $this->assertArrayHasKey('onlineGuests', $attributes);
+        $this->assertIsInt($attributes['onlineGuests']);
+    }
+
+    /**
+     * @test
+     */
+    public function guest_with_permission_receives_an_integer_count(): void
+    {
+        $this->grantPermissionTo(Group::GUEST_ID);
+
+        $attributes = $this->forumAttributes();
+
+        $this->assertArrayHasKey('onlineGuests', $attributes);
+        $this->assertIsInt($attributes['onlineGuests']);
+    }
+}

--- a/tests/unit/GuestUserCountTest.php
+++ b/tests/unit/GuestUserCountTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of ianm/online-guests.
+ *
+ * Copyright (c) IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\OnlineGuests\Tests\unit;
+
+use FoF\ForumWidgets\SafeCacheRepositoryAdapter;
+use FoF\Redis\Session\RedisSessionHandler;
+use Flarum\Settings\SettingsRepositoryInterface;
+use IanM\OnlineGuests\GuestUserCount;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Session\FileSessionHandler;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use SessionHandlerInterface;
+
+class GuestUserCountTest extends TestCase
+{
+    private string $sessionPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionPath = sys_get_temp_dir().'/ianm-online-guests-'.uniqid();
+        mkdir($this->sessionPath);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->sessionPath.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->sessionPath);
+
+        m::close();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Build a GuestUserCount with the given session handler and call the
+     * protected getGuestCount() directly. We test the counting logic in
+     * isolation; the cache + permission flow is covered by integration tests
+     * (it requires a booted container).
+     */
+    private function countFor(SessionHandlerInterface $handler, int $onlineDuration = 5): int
+    {
+        $count = new GuestUserCount(
+            $handler,
+            m::mock(SafeCacheRepositoryAdapter::class),
+            m::mock(SettingsRepositoryInterface::class),
+        );
+
+        $reflection = new \ReflectionObject($count);
+
+        $durationProp = $reflection->getProperty('onlineDurationMinutes');
+        $durationProp->setValue($count, $onlineDuration);
+
+        $method = $reflection->getMethod('getGuestCount');
+        $method->setAccessible(true);
+
+        return $method->invoke($count);
+    }
+
+    private function fileSessionHandler(): FileSessionHandler
+    {
+        return new FileSessionHandler(new Filesystem(), $this->sessionPath, 120);
+    }
+
+    /** Write a serialized session payload to a file with a fresh mtime. */
+    private function writeSession(string $id, array $payload): void
+    {
+        file_put_contents($this->sessionPath.'/'.$id, serialize($payload));
+    }
+
+    /** @test */
+    public function it_returns_zero_for_unknown_session_handler(): void
+    {
+        $handler = m::mock(SessionHandlerInterface::class);
+
+        $this->assertSame(0, $this->countFor($handler));
+    }
+
+    /** @test */
+    public function it_counts_recent_guest_sessions_from_files(): void
+    {
+        $this->writeSession('guest-a', ['_token' => 'x']);
+        $this->writeSession('guest-b', ['foo' => 'bar']);
+
+        $this->assertSame(2, $this->countFor($this->fileSessionHandler()));
+    }
+
+    /** @test */
+    public function it_excludes_logged_in_sessions(): void
+    {
+        $this->writeSession('guest', ['foo' => 'bar']);
+        $this->writeSession('member', ['access_token' => 'abc123']);
+
+        $this->assertSame(1, $this->countFor($this->fileSessionHandler()));
+    }
+
+    /** @test */
+    public function it_ignores_corrupt_session_files(): void
+    {
+        $this->writeSession('guest', ['foo' => 'bar']);
+        // A file that does not unserialize to an array (unserialize returns false).
+        file_put_contents($this->sessionPath.'/corrupt', 'this is not serialized php');
+
+        $this->assertSame(1, $this->countFor($this->fileSessionHandler()));
+    }
+
+    /** @test */
+    public function it_ignores_sessions_outside_the_online_window(): void
+    {
+        $this->writeSession('recent', ['foo' => 'bar']);
+
+        $this->writeSession('stale', ['foo' => 'bar']);
+        // Backdate well beyond the 5 minute window.
+        touch($this->sessionPath.'/stale', time() - 3600);
+
+        $this->assertSame(1, $this->countFor($this->fileSessionHandler(), 5));
+    }
+
+    /** @test */
+    public function it_returns_zero_when_no_sessions_exist(): void
+    {
+        $this->assertSame(0, $this->countFor($this->fileSessionHandler()));
+    }
+
+    /** @test */
+    public function it_dispatches_to_redis_for_a_redis_session_handler(): void
+    {
+        $connection = m::mock();
+        $connection->shouldReceive('zremrangebyscore')->once();
+        $connection->shouldReceive('zcard')->once()->andReturn(7);
+
+        $store = m::mock(RedisStore::class);
+        $store->shouldReceive('connection')->andReturn($connection);
+
+        $cache = m::mock();
+        $cache->shouldReceive('getStore')->andReturn($store);
+
+        $handler = m::mock(RedisSessionHandler::class);
+        $handler->shouldReceive('getCache')->andReturn($cache);
+
+        $this->assertSame(7, $this->countFor($handler));
+    }
+
+    /** @test */
+    public function it_returns_zero_when_redis_throws(): void
+    {
+        $handler = m::mock(RedisSessionHandler::class);
+        $handler->shouldReceive('getCache')->andThrow(new \RuntimeException('redis down'));
+
+        $this->assertSame(0, $this->countFor($handler));
+    }
+}

--- a/tests/unit/GuestUserCountTest.php
+++ b/tests/unit/GuestUserCountTest.php
@@ -11,9 +11,9 @@
 
 namespace IanM\OnlineGuests\Tests\unit;
 
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\ForumWidgets\SafeCacheRepositoryAdapter;
 use FoF\Redis\Session\RedisSessionHandler;
-use Flarum\Settings\SettingsRepositoryInterface;
 use IanM\OnlineGuests\GuestUserCount;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Filesystem\Filesystem;


### PR DESCRIPTION
Adds the first PHPUnit test coverage for the extension.

## Tests

**Unit — `GuestUserCount`**
- Unknown session handler returns `0`
- File driver: counts guest sessions, excludes logged-in sessions (`access_token`), ignores corrupt files, respects the recency window, empty dir returns `0`
- Redis driver: dispatches to `fromRedis()` (mocked connection) and swallows Redis errors to return `0`

**Integration — forum API attribute**
- Guests/members without `viewOnlineGuests` do not receive the `onlineGuests` attribute
- Actors with the permission receive an integer count

This also exercises the `ApiSerializer` extender wiring and the permission gate end to end.

## Other changes

- **Harden `fromFiles()`** against corrupt session files — suppress the expected `unserialize` warning and disallow object instantiation (`allowed_classes => false`). The corrupt-file test surfaced this.
- **Bump `flarum/core` floor to `^1.8.13`** — the release that introduced `Flarum\Foundation\Event\ApplicationBooted`, which the Redis middleware listener relies on. The previous `^1.8.0` floor would fatal on 1.8.0–1.8.12.
- **Enable backend testing in CI** so the suite runs on PRs.